### PR TITLE
Adding tab-closed event

### DIFF
--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -105,8 +105,10 @@ L.Control.Sidebar = L.Control.extend({
                 for (i = this._panes.length - 1; i >= 0; i--) {  
                     if (child.id == id)
                         L.DomUtil.addClass(child, 'active');
-                    else if (L.DomUtil.hasClass(child, 'active'))
+                    else if (L.DomUtil.hasClass(child, 'active')) {
                         L.DomUtil.removeClass(child, 'active');
+                        this.fire('tab-closed', {id: child.id });
+                    }
                 }
 
                 // remove old active highlights and set new highlight
@@ -118,7 +120,7 @@ L.Control.Sidebar = L.Control.extend({
                         L.DomUtil.removeClass(child, 'active');
                 }
 
-                this.fire('content', { id: id });
+                this.fire('tab-opened', { id: id });
         
                 // open sidebar (if necessary)
                 if (L.DomUtil.hasClass(this._sidebar, 'collapsed')) {
@@ -133,8 +135,9 @@ L.Control.Sidebar = L.Control.extend({
 
     close: function() {
         // remove old active highlights
-        L.DomUtil.removeClass(this._getActiveTab(), 'active');
-
+        var tab = this._getActiveTab();
+        L.DomUtil.removeClass(tab, 'active');
+        this.fire('tab-closed', { id: tab.id });
 
         // close sidebar
         if (!L.DomUtil.hasClass(this._sidebar, 'collapsed')) {


### PR DESCRIPTION
adding a 'tab-closed' event to match the 'content' event and then renamed the 'content' event to 'tab-opening'.

Now when a user changes tabs on the sidebar the tab closing event fires letting listeners know which tab is closing, before the dom fires the 'tab-opening' event to let users know which tab is opening.  This is useful for adding and removing event listeners which are attached to a particular tab.
